### PR TITLE
Update to Go 1.18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17-alpine3.14 as builder
+FROM golang:1.18-alpine3.15 as builder
 
 # Install SSL ca certificates
 RUN apk update && apk add git && apk add ca-certificates
@@ -27,7 +27,7 @@ RUN GOOS=linux GOARCH=amd64 go build --tags=build -o /go/bin/representer ./cmd/r
 # Build a minimal and secured container
 # The ast parser needs Go installed for import statements.
 # Therefore, unfortunately we cannot build from scratch as we would normally do with Go.
-FROM golang:1.17-alpine3.14
+FROM golang:1.18-alpine3.15
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /etc/passwd /etc/passwd
 COPY --from=builder /go/bin /opt/representer/bin

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/exercism/go-representer
 
-go 1.17
+go 1.18
 
 require (
 	github.com/matryer/is v1.4.0


### PR DESCRIPTION
As per below issue:

https://github.com/exercism/go-representer/issues/20

This PR updates Go to version 1.18