### PR TITLE
Add batch analysis script

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,7 @@ The basic normalizations recommended in the [docs](https://exercism.org/docs/bui
 * Apply standard formatting
 * Consolidate multiple files
 * Sort top level declarations (imports, types, constants, variables, functions)
+
+## Batch Analysis
+
+See [Batch Analysis README](https://github.com/exercism/go-representer/blob/main/script/README.md) for information on how to run the representer on a bigger data set.

--- a/script/README.md
+++ b/script/README.md
@@ -1,0 +1,30 @@
+# Batch Execution Script
+
+This folder contains a Go program to run the representer against a set of student solutions.
+The program prints some information on how many solutions had the same representation and which ones were unique.
+
+As input, the program expects a extracted (not zipped) directory with 500 student solutions in folders with names from 0 to 499.
+You can get this data set via the endpoint `https://exercism.org/api/v2/tracks/{track}/exercises/{exercise-slug}/export_solutions`.
+The endpoint is only available for maintainers and only allows to download a couple of data sets per day.
+
+After you downloaded and unzipped the solutions, you can run the analysis by execting the following command in the root folder of this repository.
+```bash
+go run ./script/batch_exec.go <path-to-solutions-folder>
+```
+
+If you make improvements to the script that others could benefit from as well, please create a PR.
+
+Example outout of the program (shortened for readability):
+```text
+101 solutions have the same representation as solution 2.
+47 solutions have the same representation as solution 5.
+26 solutions have the same representation as solution 7.
+19 solutions have the same representation as solution 15.
+14 solutions have the same representation as solution 21.
+12 solutions have the same representation as solution 17.
+[...]
+
+120 unique solutions: [0 4 8 10 29 30 31 32 34 40 55 ... 348 350 361 362 366 375 376 377 380 381 386 389 393 394 398 419 420 423 427 428 438 440 441 446 449 471 474 475 479 480 484 486 496 497]
+
+Number of solutions that did not compile or failed the tests:  4
+```

--- a/script/batch_exec.go
+++ b/script/batch_exec.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"sort"
+
+	"github.com/exercism/go-representer"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		log.Fatal("please provide the path to the folder with the examples as argument")
+	}
+
+	goExe, err := exec.LookPath("go")
+	if err != nil {
+		log.Fatalf("failed to find go: %v", err)
+	}
+
+	examplesPath := os.Args[1]
+
+	representationToSolutions := map[string][]int{}
+	solutionsWithCompilerOrTestFailure := 0
+
+	for i := 0; i < 500; i++ {
+		// Write a log every 10 solutions so we can see some progress in the terminal
+		// and notice if the processing is stuck.
+		if i > 0 && i%10 == 0 {
+			fmt.Printf("%d solutions processed\n", i)
+		}
+
+		pathToSolutionFolder := fmt.Sprintf("%s/%d", examplesPath, i)
+		testCmd := &exec.Cmd{
+			Dir:  pathToSolutionFolder,
+			Path: goExe,
+			Args: []string{"go", "test", "-timeout", "10s"},
+		}
+		err = testCmd.Run()
+		if err != nil {
+			solutionsWithCompilerOrTestFailure++
+			continue
+		}
+
+		reprBytes, _, err := representer.Extract(pathToSolutionFolder)
+		if err != nil {
+			log.Fatalf("representer failed: %v", err)
+		}
+
+		err = os.WriteFile(pathToSolutionFolder+"/.meta/representation.txt", reprBytes, 0644)
+		if err != nil {
+			fmt.Printf("Failed to write representation for solution %d.\n", i)
+		}
+
+		representation := string(reprBytes)
+		representationToSolutions[representation] = append(representationToSolutions[representation], i)
+	}
+
+	fmt.Printf("\nAll solutions processed!\n\n")
+
+	type group struct {
+		count     int
+		solutions []int
+	}
+
+	groups := []group{}
+	uniqueSolutions := []int{}
+
+	for _, solutions := range representationToSolutions {
+		if len(solutions) == 1 {
+			uniqueSolutions = append(uniqueSolutions, solutions[0])
+			continue
+		}
+
+		groups = append(groups, group{
+			count:     len(solutions),
+			solutions: solutions,
+		})
+	}
+
+	sort.Slice(groups, func(i, j int) bool { return groups[i].count > groups[j].count })
+	sort.Ints(uniqueSolutions)
+
+	for _, group := range groups {
+		fmt.Printf("%d solutions have the same representation as solution %d.\n", group.count, group.solutions[0])
+	}
+	fmt.Printf("\n%d unique solutions: %v\n\n", len(uniqueSolutions), uniqueSolutions)
+	fmt.Println("Number of solutions that did not compile or failed the tests: ", solutionsWithCompilerOrTestFailure)
+}


### PR DESCRIPTION
I wrote a small Go script that allows to run the representer against the 500 solutions data set. See readme file in PR for more info.

I nearly lost the script myself so I am proposing to add it to the repository. It is not part of the production code so no super thorough code review needed.