### PR TITLE
Fix import issue

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
           context: .
           push: false
           load: true
-          tags: exercism/go-test-runner
+          tags: exercism/go-representer
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,32 +3,26 @@ FROM golang:1.20.1-alpine3.17 as builder
 # Install SSL ca certificates
 RUN apk update && apk add git && apk add ca-certificates
 
-# Create appuser
-RUN adduser -D -g '' appuser && mkdir /go-representer
+# Add a non-root user to run our code as
+RUN adduser --disabled-password appuser
 
-# source code
-WORKDIR /go-representer
-COPY ./go.mod /go-representer/go.mod
+# Copy the source code into the container
+# and make sure appuser owns all of it
+COPY --chown=appuser:appuser . /opt/representer
 
-# download dependencies
+# Build and run the representer with appuser
+USER appuser
+
+# This populates the build cache with the standard library
+# so future compilations are faster
+RUN go build std
+
+WORKDIR /opt/representer
+
+# Download dependencies
 RUN go mod download
 
-# get the rest of the source code
-COPY . /go-representer
-
 # build
-RUN go generate .
-RUN GOOS=linux GOARCH=amd64 go build --tags=build -o /go/bin/representer ./cmd/representer
+RUN go build --tags=build -o /opt/representer/bin/representer ./cmd/representer
 
-# Build a minimal and secured container
-# The ast parser needs Go installed for import statements.
-# Therefore, unfortunately we cannot build from scratch as we would normally do with Go.
-FROM golang:1.20.1-alpine3.17
-COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-COPY --from=builder /etc/passwd /etc/passwd
-COPY --from=builder /go/bin /opt/representer/bin
-COPY bin/run.sh /opt/representer/bin/
-
-USER appuser
-WORKDIR /opt/representer
-ENTRYPOINT ["/opt/representer/bin/run.sh"]
+ENTRYPOINT ["sh", "/opt/representer/bin/run.sh"]

--- a/bin/run-tests.sh
+++ b/bin/run-tests.sh
@@ -18,11 +18,14 @@ filenames="representation.txt mapping.json"
 for test_dir in testdata/*/*; do
     test_dir_name=$(basename "${test_dir}")
     test_dir_path=$(realpath "${test_dir}")
+    output_dir_path="/tmp/${test_dir_name}"
 
-    bin/run.sh "${test_dir_name}" "${test_dir_path}" "${test_dir_path}"
+    mkdir -p "${output_dir_path}"
+
+    bin/run.sh "${test_dir_name}" "${test_dir_path}" "${output_dir_path}"
 
     for filename in $filenames; do
-        actual_filepath="${test_dir_path}/${filename}"
+        actual_filepath="${output_dir_path}/${filename}"
         expected_filepath="${test_dir_path}/expected_${filename}"
         
         echo "${test_dir_name}: comparing ${filename} to expected_${filename}"


### PR DESCRIPTION
Fixes #35 

I changed the Dockerfile to be the same as for the test runner and that fixed the issue. I think if that Dockerfile is secure enough for the test runner it should be fine for the representer as well.

`./bin/run-in-docker.sh two-fer ./testdata/two-fer/2/ ./` would give the error in the issue description before the fix and no error afterwards with correct representation output. `./bin/run-tests-in-docker.sh` also works locally now (no error, success exit code).
Don't ask me why exactly the old version did not work anymore. With the test runner we only had issues that things were slow after updating to 1.20 with a sub-optimal docker file but never any failures.